### PR TITLE
Include Pocket Network docs, features, and links

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -115,6 +115,26 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
     - Unique Ethereum SDK
     - Unique API endpoints
     - Direct, technical support
+- [**Pocket Network**](https://www.pokt.network/)
+  - [Docs](https://docs.pokt.network/home/)
+  - Features
+    - Decentralized RPC Protocol and Marketplace
+    - 1M Requests Per Day Free Tier (per endpoint, max 2)
+    - [Public Endpoints](https://docs.pokt.network/home/resources/public-rpc-endpoints)
+    - Pre-Stake+ Program (if you need more than 1M requests per day)
+    - 15+ Blockchains Supported
+    - 6400+ Nodes earning POKT for serving applications
+    - Archival Node, Archival Node w/ Tracing, & Testnet Node Support
+    - Ethereum Mainnet Node Client Diversity 
+    - No Single Point of Failure
+    - Zero Downtime
+    - Cost-Effective Near-Zero Tokenomics (stake POKT once for network bandwidth)
+    - No monthly sunk costs, turn your infrastructure into an asset
+    - Load-Balancing built into the Protocol
+    - Infinitely scale the number of requests per day and nodes per hour as you go
+    - The most private, censorship-resistant option
+    - Hands-on developer support
+    - [Pocket Portal](https://bit.ly/ETHorg_POKTportal) dashboard and analytics 
 - [**QuikNode**](https://www.quiknode.io/)
   - Features
     - 7 day free trial


### PR DESCRIPTION
I've added Pocket Network along with its docs, features, and links

## Description

Added Pocket Network to the list of Nodes as a Service
Highlighted features
Hyperlinked Website, Docs, Public Endpoints, and Pocket Portal (front-end for Pocket Network protocol that enables developers to mint RPC endpoints and view analytics)

## Related Issue 

[Add Pocket Network to our Nodes as a Service #4033](https://github.com/ethereum/ethereum-org-website/pull/4033/commits)
